### PR TITLE
Fix allow comparison of differtent type

### DIFF
--- a/common/changes/@educorvi/rita/fix-allow_comparison_of_differtent_type-YT-JSO-2_2024-06-21-13-39.json
+++ b/common/changes/@educorvi/rita/fix-allow_comparison_of_differtent_type-YT-JSO-2_2024-06-21-13-39.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@educorvi/rita",
+      "comment": "add ´allowDifferentTypes´ option to comparisons",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@educorvi/rita"
+}

--- a/rita-core/src/Parser.ts
+++ b/rita-core/src/Parser.ts
@@ -186,11 +186,7 @@ export default class Parser {
                     throw new UsageError('Invalid Date: ' + parameter);
                 }
             } else {
-                if (typeof parameter === 'number') {
-                    params.push(parameter);
-                } else {
-                    params.push(parameter);
-                }
+                params.push(parameter);
             }
         }
         return params;
@@ -207,7 +203,8 @@ export default class Parser {
                 jsonRuleset['dates']
             ),
             jsonRuleset['operation'],
-            jsonRuleset['dates']
+            jsonRuleset['dates'],
+            jsonRuleset['allowDifferentTypes']
         );
     }
 

--- a/rita-core/src/logicElements/Comparison.ts
+++ b/rita-core/src/logicElements/Comparison.ts
@@ -34,20 +34,28 @@ export class Comparison extends Formula {
     public dates: boolean;
 
     /**
+     * Indicates if different types are allowed inside a comparison
+     */
+    public allowDifferentTypes: boolean;
+
+    /**
      * @constructor
      * @param formulaArguments The arguments
      * @param operation Type of the comparison
      * @param dates Indicates if dates are compared
+     * @param allowDifferentTypes Indicates if different types are allowed inside a comparison
      */
     constructor(
         formulaArguments: Array<Atom | number | Date | string | Calculation>,
         operation: comparisons,
-        dates: boolean = false
+        dates: boolean = false,
+        allowDifferentTypes: boolean = false
     ) {
         super();
         this.arguments = formulaArguments;
         this.operation = operation;
         this.dates = dates;
+        this.allowDifferentTypes = allowDifferentTypes;
     }
 
     toJsonReady(): Record<string, any> {
@@ -74,9 +82,11 @@ export class Comparison extends Formula {
         if (p1 === undefined || p2 === undefined) return false;
 
         if (typeof p1 !== typeof p2) {
-            throw new UsageError(
-                'Elements in comparison must have the same type'
-            );
+            if (!this.allowDifferentTypes) {
+                throw new UsageError(
+                    'Elements in comparison must have the same type'
+                );
+            }
         }
 
         if (p1 instanceof Date) p1 = p1.getTime();

--- a/rita-core/src/schema/comparison.json
+++ b/rita-core/src/schema/comparison.json
@@ -25,6 +25,11 @@
             "type": "boolean",
             "default": false
         },
+        "allowDifferentTypes": {
+            "description": "Indicates if different types are allowed inside a comparison. This follows the JavaScript rules for comparison (´===´ is used for ´equals´).",
+            "type": "boolean",
+            "default": false
+        },
         "arguments": {
             "type": "array",
             "minItems": 2,

--- a/rita-core/test/implementationTests/comparison.test.ts
+++ b/rita-core/test/implementationTests/comparison.test.ts
@@ -1,10 +1,4 @@
-import {
-    Comparison,
-    comparisons,
-    evaluateAll,
-    Parser,
-    UsageError,
-} from '../../src';
+import { evaluateAll, Parser, UsageError } from '../../src';
 // @ts-ignore
 import { exampleData, ruleTemplate } from '../assets/exampleData';
 // @ts-ignore
@@ -116,11 +110,25 @@ it('run math example', async () => {
 });
 
 it('error on different type', async () => {
-    const c = new Comparison([2, 'Test'], comparisons.equal);
+    const c = p.parseComparison({
+        type: 'comparison',
+        operation: 'smaller',
+        arguments: [2, '2'],
+    });
     try {
         await c.evaluate({});
         expect(true).toBe(false);
     } catch (e) {
         expect(e).toBeInstanceOf(UsageError);
     }
+});
+
+it('compare number with string', async () => {
+    const c = p.parseComparison({
+        type: 'comparison',
+        operation: 'equal',
+        allowDifferentTypes: true,
+        arguments: [2, '2'],
+    });
+    expect(await c.evaluate({})).toBe(false);
 });


### PR DESCRIPTION
Allow comparison for different types when the ´allowDifferentTypes´ option is set.

For YT JSO-2